### PR TITLE
Stirling README suggestions

### DIFF
--- a/documentation/starter-kits/README.md
+++ b/documentation/starter-kits/README.md
@@ -74,3 +74,24 @@ This template was influenced by the following sources:
 - [Kubernetes Contributors Guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 - [SciKit Learn Contributors Guide](https://scikit-learn.org/dev/developers/contributing.html)
 - [Django Contributors Guide](https://docs.djangoproject.com/en/dev/internals/contributing)
+
+## Change Log
+
+A change log provides a *human readable* list of significant changes, additions, deprecations, removals for software over time. It is meant to be able to be read by *people*. Change logs should be documented within a file called `CHANGELOG.md` and be updated per key release. See [semantic release](https://semver.org) for guidance on releasing cycles and versioning of your software. 
+
+⚠️ A `CHANGELOG.md` can replicate wording from a releases page (e.g. GitHub Releases), but should not be left out *in place of* a releases page. Down-stream inheritors of your software may not have access to your releases page, and will expect a `CHANGELOG.md` to be present as part of your software distribution.
+
+### Keep a Changelog
+
+This change log standard seeks to provide a template for *human readable* change logs, among other key guidance on the change logging process.
+
+Starter Kit:
+- [Guidance](https://keepachangelog.com/en/1.0.0/#how)
+- [Demo](https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md)
+- [Webpage](https://keepachangelog.com/en/1.0.0/)
+
+To leverage this template, make sure to do the following:
+1. Talk with your team about leveraging this template, and seek wide agreement before you adopt
+2. Copy the demo `CHANGELOG.md` above, and place in a file within your repository called `CHANGELOG.md` 
+3. Edit the `CHANGELOG.md` file with your specific release information. If you have many historic releases prior to the creation of this file, mark the latest release as the first entry, and commit to updating this for future releases as the happen.
+4. Add an entry to your `README.md` under the `Changelog` section to point to your `CHANGELOG.md` file.

--- a/documentation/starter-kits/READMEs/README-sw-proj-template.md
+++ b/documentation/starter-kits/READMEs/README-sw-proj-template.md
@@ -70,13 +70,15 @@
 5. Instructions (with optional screenshots)
 6. And expected outputs (with optional screenshots)
 
+<!-- ☝️ Replace with a bullet-point list of your run instructions, including expected results ☝️ -->
+
 ### Usage Examples
 
 * Provide list of a few common usage examples for running your software here. 
 * Link to your documentation for more examples and details.
 * Provide screenshots! They can be extremely helpful in verifying results.
 
-<!-- ☝️ Replace with a bullet-point list of your run instructions, including expected results ☝️ -->
+<!-- ☝️ Replace with a bullet-point list of your usage examples, including screenshots if possible ☝️ -->
 
 ### Build Instructions (if applicable)
 

--- a/documentation/starter-kits/READMEs/README-sw-proj-template.md
+++ b/documentation/starter-kits/READMEs/README-sw-proj-template.md
@@ -70,6 +70,12 @@
 5. Instructions (with optional screenshots)
 6. And expected outputs (with optional screenshots)
 
+### Usage Examples
+
+* Provide list of a few common usage examples for running your software here. 
+* Link to your documentation for more examples and details.
+* Provide screenshots! They can be extremely helpful in verifying results.
+
 <!-- ☝️ Replace with a bullet-point list of your run instructions, including expected results ☝️ -->
 
 ### Build Instructions (if applicable)
@@ -96,20 +102,9 @@
 
 ## Changelog
 
-[Link to releases page OR filled out below]
+[Link to your CHANGELOG.md]
 
-* 0.2.1
-    * CHANGE: Fixed dead links in docs
-* 0.2.0
-    * CHANGE: Deprecated ...
-    * ADD: New ABC feature
-* 0.1.1
-    * FIX: bug where XYZ happened
-* 0.1.0
-    * Inital working release
-    * CHANGE: Rename `foo()` to `bar()`
-* 0.0.1
-    * ADD: Feature 1 and 2 implemented
+[Additional link to your releases page if you have one]
 
 <!-- ☝️ Replace with a bullet-point list of your release notes like above, or just link to your releases page ☝️ -->
 


### PR DESCRIPTION
## Purpose
- Incorporate suggestions provided by @stirlingalgermissen
## Proposed Changes
- [ADD] new `CHANGELOG.md` template section within starter kits
- [ADD] new "Usage examples" section within readme template
- [CHANGE] README wording to provide link to changelog instead of inline
## Testing
- Example of updated README here: https://github.com/riverma/terraformly/blob/main/README.md
- Starterkit section tested locally using RETYPE on Mac OSX Big Sur & Safari 15.3 (see example below)
<img width="1056" alt="Screen Shot 2022-03-30 at 5 57 43 PM" src="https://user-images.githubusercontent.com/3129134/160955111-f090a43e-3881-4a24-9960-1b6aa36318e4.png">
