### PR TITLE
Proposed LICENSE text file w/ JPL-Caltech attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,33 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
+      Copyright (c) 2020 California Institute of Technology ("Caltech").
+      U.S. Government sponsorship acknowledged.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+      All rights reserved.
 
-   Copyright [yyyy] [name of copyright owner]
+      Redistribution and use in source and binary forms, with or without modification, are permitted provided
+      that the following conditions are met:
+      * Redistributions of source code must retain the above copyright notice, this list of conditions and
+      the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+      and the following disclaimer in the documentation and/or other materials provided with the
+      distribution.
+      * Neither the name of Caltech nor its operating division, the Jet Propulsion Laboratory, nor the
+      names of its contributors may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+      IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+      THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+      PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+      CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+      EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+      PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+      OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+      WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+      OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+      ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Purpose
- New LICENSE text with JPL/Caltech attribution
- Text works just fine with GitHub license automation panel to provide quick summary
## Proposed Changes
- [ADD] License file
## Testing
* For live example of Apache license, see: https://github.com/riverma/github_test_area/blob/test-jpl-markup/LICENSE#L178-L204
