### PR TITLE
Slim badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The fastest way to start using SLIM process improvement solutions is to take a l
 
 We recommend creating pull-requests using our starter kits against your own repositories. Reach out to our [contributor communication channels](CONTRIBUTING.md#communication-channels) for questions if you're unsure how to create pull requests. An excellent tool to automate the infusion of starter kits in your repositories (especially if you have many) is to use a tool like [multi-gitter](https://github.com/lindell/multi-gitter) if you're using Git to create pull-requests. 
 
+Finally, if you use any of our guides - please consider adding the following badge to your `README.md`: 
+[![SLIM](https://img.shields.io/badge/Best%20Practices%20from-SLIM-blue)]([code_of_conduct.md](https://nasa-ammos.github.io/slim/))
+
 ### Contribute to Our Guides
 
 We're excited to see your contribution! Please see our [Contributing Guide](CONTRIBUTING.md) on details for how to contribute. We accept many non-code contributions as well, so feel free to think creatively. 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The fastest way to start using SLIM process improvement solutions is to take a l
 We recommend creating pull-requests using our starter kits against your own repositories. Reach out to our [contributor communication channels](CONTRIBUTING.md#communication-channels) for questions if you're unsure how to create pull requests. An excellent tool to automate the infusion of starter kits in your repositories (especially if you have many) is to use a tool like [multi-gitter](https://github.com/lindell/multi-gitter) if you're using Git to create pull-requests. 
 
 Finally, if you use any of our guides - please consider adding the following badge to your `README.md`: 
-[![SLIM](https://img.shields.io/badge/Best%20Practices%20from-SLIM-blue)]([code_of_conduct.md](https://nasa-ammos.github.io/slim/))
+[![SLIM](https://img.shields.io/badge/Best%20Practices%20from-SLIM-blue)](https://nasa-ammos.github.io/slim/)
 
 ### Contribute to Our Guides
 

--- a/documentation/starter-kits/READMEs/README-sw-proj-template.md
+++ b/documentation/starter-kits/READMEs/README-sw-proj-template.md
@@ -17,7 +17,7 @@
 
 <!-- Header block for project -->
 
-[INSERT YOUR BADGES HERE (SEE: https://shields.io)]
+[INSERT YOUR BADGES HERE (SEE: https://shields.io)] [![SLIM](https://img.shields.io/badge/Best%20Practices%20from-SLIM-blue)](https://nasa-ammos.github.io/slim/)
 <!-- ☝️ Add badges via: https://shields.io e.g. ![](https://img.shields.io/github/your_chosen_action/your_org/your_repo) ☝️ -->
 
 [INSERT SCREENSHOT OF YOUR SOFTWARE, IF APPLICABLE]


### PR DESCRIPTION
## Purpose
- Adding a pluggable badge to point to SLIM project, if people use SLIM resources
## Proposed Changes
- [CHANGE] Point folks to use SLIM badge if they're leveraging SLIM in their project, within the 'Get Involved' section
- [CHANGE] Software README template to, by default, include SLIM badge
## Issues
- None
## Testing
- Tested on GH markdown rendering [here](https://github.com/NASA-AMMOS/slim/blob/slim-badge/README.md#use-our-guides)
