### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/docs/guides/governance/contributions/contributing-guide/CONTRIBUTING.md
+++ b/docs/guides/governance/contributions/contributing-guide/CONTRIBUTING.md
@@ -15,10 +15,6 @@ Our project has our licensing terms, including rules governing redistribution, d
 
 Our Code of Conduct helps facilitate a positive interaction environment for everyone involved with the team, and provides guidance on what to do if you experience problematic behavior. Read more in our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and make sure you agree to its terms. 
 
-### Governance Model
-
-Our Governance model helps outline our project's decision making and roles-based expectations. Read more in our [GOVERNANCE.md](GOVERNANCE.md). 
-
 ### Developer Environment
 
 For patch contributions, see our [Developer Documentation]([INSERT YOUR DEVELOPMENT GUIDE LINK HERE]) for more details on how to set up your local environment, to best contribute to our project. 


### PR DESCRIPTION
Remove GOVERNANCE model bit for now, since we're still working on a recommendation for smaller projects (we have one available for large projects only right now).

## Purpose
- Remove GOVERNANCE.md section because we're not currently able to recommend a governance approach for all sized teams (only large teams currently) from our guide. Once [our guide](https://nasa-ammos.github.io/slim/docs/guides/governance/governance-model/) is augmented we can add this section back. 
## Proposed Changes
- [REMOVE] - GOVERNANCE.md section
## Issues
- N/A
## Testing
- Markdown preview
