### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2024-09-30
+
+### Added
+- New container security best practices guide
+- SLIM-CLI support
+
+### Changed
+- Updated `slim-registry.json` with new governance models
+- Improved dependency handling: `braces`, `@babel/traverse`, `ws`
+- Enhanced project security and containerization practices
+
+For more details, visit the [release page](https://github.com/NASA-AMMOS/slim/releases/tag/v1.6.0). 
+
+
 ## [1.4.0] - 2024-03-26
 
 ### Added


### PR DESCRIPTION
## Purpose
- Update CHANGELOG.md based on the latest release [v1.6.0](https://github.com/NASA-AMMOS/slim/releases/tag/v1.6.0). 
## Proposed Changes
- [ADD] Updated CHANGELOG.md to reflect changes introduced in v1.6.0.
## Issues
- Missing CHANGELOG.md update for release v1.6.0. 
- Related issue: #166 
## Testing
- No tests required for documentation update.