### PR TITLE
Replace slim-detect-secrets with official detect-secrets repository

### DIFF
--- a/docs/guides/software-lifecycle/security/secrets-detection/README.md
+++ b/docs/guides/software-lifecycle/security/secrets-detection/README.md
@@ -40,17 +40,15 @@ To get the most out of `detect-secrets`, you'll need:
 ## Quick Start
 
 1. Install slim-detect-secrets:
-  
-  > ℹ️ **Note:** the SLIM project has customized the Detect Secrets tool to identify additional sensitive keywords such as IP addresses, file paths, and AWS information. These additions are currently [under review](https://github.com/Yelp/detect-secrets/pulls/perryzjc) by the detect-secrets team for merge into the tool's `main` codebase. Until then we recommend using our SLIM fork as described below. 
    
    ```bash
-   pip install git+https://github.com/NASA-AMMOS/slim-detect-secrets.git@exp
+   pip install git+https://github.com/Yelp/detect-secrets.git
    ```
    
 2. Execute a baseline scan:
 
    ```bash
-   detect-secrets scan --all-files --disable-plugin AbsolutePathDetectorExperimental --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
+   detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
    ```
 
 3. Review the `.secrets.baseline` file for any detected secrets via an audit:
@@ -77,15 +75,15 @@ This layer directly scans the developer's local environment using the `detect-se
 
 #### Steps
 1. **Installation**
-   - Install the experimental version of [slim-detect-secrets](https://github.com/NASA-AMMOS/slim-detect-secrets/tree/exp).
+   - Install [detect-secrets](https://github.com/Yelp/detect-secrets).
      ```bash
-     pip install git+https://github.com/NASA-AMMOS/slim-detect-secrets.git@exp
+     pip install git+https://github.com/Yelp/detect-secrets.git
      ```
 
 2. **Scanning**
    - Scan all local files from the current directory and output results to a baseline file.
      ```bash
-     detect-secrets scan --all-files --disable-plugin AbsolutePathDetectorExperimental --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
+     detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
      ```
 
 3. **Checking Results**

--- a/docs/guides/software-lifecycle/security/secrets-detection/README.md
+++ b/docs/guides/software-lifecycle/security/secrets-detection/README.md
@@ -48,7 +48,7 @@ To get the most out of `detect-secrets`, you'll need:
 2. Execute a baseline scan:
 
    ```bash
-   detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
+   detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git.*' > .secrets.baseline
    ```
 
 3. Review the `.secrets.baseline` file for any detected secrets via an audit:
@@ -81,9 +81,9 @@ This layer directly scans the developer's local environment using the `detect-se
      ```
 
 2. **Scanning**
-   - Scan all local files from the current directory and output results to a baseline file.
+   - Scan all local files from the current directory and output results to a baseline file. Note: add additional `--exclude-files` as needed using regular expression patterns.
      ```bash
-     detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git*' > .secrets.baseline
+     detect-secrets scan --all-files --exclude-files '\.secrets.*' --exclude-files '\.git.*' > .secrets.baseline
      ```
 
 3. **Checking Results**

--- a/static/assets/software-lifecycle/security/secrets-detection/detect-secrets.yaml
+++ b/static/assets/software-lifecycle/security/secrets-detection/detect-secrets.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Upgrade tooling
       run: |
         python3 -m pip install --upgrade pip
-        pip install --upgrade git+https://github.com/NASA-AMMOS/slim-detect-secrets.git@exp
+        pip install --upgrade git+https://github.com/Yelp/detect-secrets.git
         pip install --upgrade jq
     - name: Create baseline config
       run: |
@@ -66,7 +66,7 @@ jobs:
             echo "" >&2
             echo "Please follow the steps below on your local machine to reveal and handle the secrets:" >&2
             echo "" >&2
-            echo "1️⃣ Run the 'detect-secrets' tool on your local machine. This tool will identify and clean up the secrets. You can find detailed instructions at this link: https://nasa-ammos.github.io/slim/continuous-testing/starter-kits/#detect-secrets" >&2
+            echo "1️⃣ Run the 'detect-secrets' tool on your local machine. This tool will identify and clean up the secrets. You can find detailed instructions at this link: https://nasa-ammos.github.io/slim/docs/guides/software-lifecycle/security/secrets-detection/#detect-secrets" >&2
             echo "" >&2
             echo "2️⃣ After cleaning up the secrets, commit your changes and re-push your update to the repository." >&2
             echo "" >&2

--- a/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml
+++ b/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml
@@ -1,7 +1,6 @@
 repos:
-  - repo: https://github.com/NASA-AMMOS/slim-detect-secrets
-    # using commit id for now, will change to tag when official version is released
-    rev: 91e097ad4559ae6ab785c883dc5ed989202c7fbe
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args:

--- a/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml
+++ b/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml
@@ -7,6 +7,6 @@ repos:
           - '--baseline'
           - '.secrets.baseline'
           - '--exclude-files'
-          - '\.git*'
+          - '\.git.*'
           - '--exclude-files'
           - '\.secrets.*' 


### PR DESCRIPTION
## Purpose
- This PR updates the documentation and configuration files to replace the usage of the `slim-detect-secrets` fork with the official `detect-secrets` repository from Yelp.
- Ensures consistency across installation commands, CI configurations, and pre-commit hooks.

## Proposed Changes
- **[CHANGE]** Updated installation instructions in `README.md` to use `pip install git+https://github.com/Yelp/detect-secrets.git` instead of the SLIM fork.
- **[CHANGE]** Removed mentions of SLIM customizations that are no longer needed.
- **[CHANGE]** Adjusted `detect-secrets` scan commands by removing the `AbsolutePathDetectorExperimental` plugin flag.
- **[CHANGE]** Updated CI workflow (`detect-secrets.yaml`) to install `detect-secrets` from the official repository.
- **[CHANGE]** Updated the pre-commit hook configuration to point to `https://github.com/Yelp/detect-secrets` at `v1.5.0`, replacing the previous SLIM fork.

## Issues
- #184 

## Testing
- Verified the updated installation command successfully installs `detect-secrets`.
- Ran `detect-secrets scan --all-files` to ensure it works as expected with the new installation.
- Checked pre-commit hook updates and confirmed they function correctly.