### PR TITLE
Add Lightweight Metrics Collection Using DeveloperMetrics GitHub Action

### DIFF
--- a/docs/guides/software-lifecycle/metrics/README.md
+++ b/docs/guides/software-lifecycle/metrics/README.md
@@ -7,29 +7,51 @@
 
 ## Introduction
 
-Metrics collection is important for project management and software quality assurance. We recommend [Apache DevLake](https://devlake.apache.org/) for easy tracking and analysis. This guide simplifies its installation and configuration, especially for developers new to metrics collection.
+Metrics collection is important for project management and software quality assurance. This guide provides two tool recommendations for collecting and visualizing metrics, depending on the complexity of your project:
+- For complex, multi-repository metrics gathering: We recommend [Apache DevLake](https://devlake.apache.org/) for detailed metrics tracking and analysis.
+- For simpler, single-repository projects: We recommend using GitHub Actions-based tools for easy integration and basic metrics collection. Specifically, the [DeveloperMetrics GitHub Action](https://github.com/DeveloperMetrics), which enables you to quickly gather and display DORA metrics with minimal configuration.
 
 **Use Cases**:
 
 - Collecting and analyzing [DORA metrics](https://devlake.apache.org/docs/DORA/) along with many others for your project.
 - Creating a visual dashboard to view metrics from multiple sources (e.g., GitHub, JIRA) in one place.
-- Streamlining the setup and configuration of Apache DevLake through a *single-command* setup step.
-- Gain insight into organizational and project performance for software development and the overall software lifecycle.
+- Streamlining the setup and configuration of metrics collection through a single-command setup step or plug-and-play GitHub Action.
+- Simplifying metrics collection for smaller projects to encourage broader adoption.
 
-**Why We Chose Apache DevLake:**
 
-Our decision to select Apache DevLake was informed by thorough trade study documentation, available [here](https://github.com/NASA-AMMOS/slim/issues/117#issuecomment-1802302091).
+## Tool Options
 
----
+### 1. **Apache DevLake** for Complex Multi-Repository Projects
 
-## Prerequisites
+DevLake is a powerful and flexible tool for gathering and visualizing software lifecycle metrics across multiple repositories. It requires Docker and some configuration but is ideal for teams managing several repositories or those needing in-depth metrics analysis.
 
+**Prerequisites**: 
 - Familiarity with [Docker](https://docs.docker.com/engine/install/) as well as a running instance of it
 - A familiarity with validated software metrics is not required for this tool but it is recommended
 
+**Why We Chose Apache DevLake**:
+
+- Our decision to select Apache DevLake was informed by thorough trade study documentation, available [here](https://github.com/NASA-AMMOS/slim/issues/117#issuecomment-1802302091).
+- Offers detailed metrics analysis for complex projects.
+- Supports various data sources (GitHub, Jira, etc.) and can create powerful visual dashboards.
+- Well-suited for projects requiring a deeper understanding of organizational and project performance.
+
+
+### 2. **DeveloperMetrics GitHub Action** for Simple Single-Repository Projects
+
+For smaller, simpler projects, where full DevLake setup might be too cumbersome, we recommend the [DeveloperMetrics GitHub Action](https://github.com/DeveloperMetrics). This tool allows you to quickly collect basic DORA metrics (e.g., deployment frequency, lead time for changes) and display results as badges in your project README.
+
+**Why We Recommend DeveloperMetrics**:
+
+- Lightweight, quick to integrate into any GitHub repository via GitHub Actions.
+- No server setup or Docker required—ideal for developers who want an easy solution.
+- Automatically collects basic DORA metrics, with results visible as badges on your repository.
+- SLIM can automatically submit PRs to infuse this action into repositories, making it easier to adopt.
+
+
 ---
 
-## Quick Start
+## Quick Start: Apache DevLake
 
 To quickly deploy DevLake on one of your servers or locally for testing, we've developed a convenient 1-step command. Please ensure Docker is running on your system before executing this command.
 
@@ -69,8 +91,37 @@ cd /path/to/your/chosen/deployment/directory
    The `-d` flag runs containers in detached mode, allowing them to run in the background.
 
 ---
+## Quick Start: DeveloperMetrics GitHub Action
 
-## Step-by-Step Configuration Guide
+To add simple metrics collection for a single repository:
+
+1. Add the following GitHub Action to your repository's `.github/workflows/metrics.yml` file:
+
+    ```yaml
+    name: Collect DORA Metrics
+    on:
+      push:
+        branches:
+          - main
+    jobs:
+      collect-metrics:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v2
+          - name: Run DORA Metrics Collection
+            uses: DeveloperMetrics/collect@v1
+            with:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    ```
+
+2. After a push to your repository, metrics such as deployment frequency and lead time for changes will be collected and displayed as badges on your project README.
+
+For more information, check out the [DeveloperMetrics repository](https://github.com/DeveloperMetrics).
+
+---
+
+## Step-by-Step Configuration Guide for DevLake 
+_For **DeveloperMetrics**, no additional configuration is needed beyond adding the GitHub Action to your repository._
 
 1. Run the **[Quick Start](#quick-start)** steps above.
 2. Once you have a working DevLake instance, we recommend going through DevLake's [official start guide](https://devlake.apache.org/docs/Overview/Introduction/#2-configuring-data-source) step-by-step, beginning with the data sources section.
@@ -109,6 +160,7 @@ See [this list](https://devlake.apache.org/docs/Metrics) of metrics on the DevLa
 
 - Dillon Dalton [ddalton-jpl](https://github.com/ddalton-jpl)
 - Rishi Verma [riverma](https://github.com/riverma)
+- Kyongsik Yun [yunks128](https://github.com/yunks128)
 
 ---
 


### PR DESCRIPTION
## Purpose  
Introduce a simplified approach for collecting DORA metrics in single-repository projects using GitHub Actions.

## Proposed Changes  
- [ADD] Section on DeveloperMetrics GitHub Action as an alternative to DevLake  
- [ADD] Quick start example YAML for easy integration  
- [UPDATE] Clarified use cases and tool selection guidance based on project complexity  

## Issues  
- Related to [[issue-160](https://github.com/NASA-AMMOS/slim/issues/160)](https://github.com/NASA-AMMOS/slim/issues/160)

## Testing  
- Verified markdown rendering locally  
