### PR TITLE
Docs: Add guidance on GitHub organization and sub-project structure

### DIFF
--- a/docs/github_org_guidance.md
+++ b/docs/github_org_guidance.md
@@ -1,0 +1,57 @@
+# GitHub Organization and Sub-Project Structure Guidance
+
+This document provides guidance on structuring your GitHub organization and sub-projects to improve collaboration, maintainability, and security.
+
+## Key Considerations
+
+When deciding on your GitHub structure, consider the following aspects, as highlighted in the [original issue discussion](https://github.com/NASA-AMMOS/slim/issues/45):
+
+*   **Role-Based Access Control (RBAC):** Different roles within a project (e.g., front-end developers, back-end developers, QA testers) may require different levels of access to repositories. A well-defined structure can facilitate granting appropriate permissions.
+*   **Code Review and Quality Assurance:** Structure your teams and repositories to streamline the code review process. Ensure pull requests are routed to the correct reviewers, and consider roles for individuals who can assign reviewers or triage pull requests.
+*   **Documentation and Communication:** Teams responsible for documentation might need read access to multiple repositories without requiring write permissions.
+*   **Continuous Integration and Deployment (CI/CD):** CI/CD processes often require specific permissions to manage webhooks, deployment keys, and triggers across repositories.
+*   **External Collaborators:** Provide temporary and restricted access to external collaborators for specific repositories as needed.
+*   **Project Management and Oversight:** Project managers and product owners may need overview access to track issues, milestones, and project boards without needing deep code access.
+*   **Triage:** Designate team members responsible for triaging issues and pull requests, including assigning them to implementers or reviewers.
+
+## Recommended Approaches
+
+While the ideal structure can vary based on project size and complexity, here are some general recommendations:
+
+### 1. Organization-Level Structure
+
+*   **Teams:** Utilize GitHub Teams to group users based on their roles and responsibilities (e.g., `developers`, `qa-team`, `documentation`, `project-managers`, `external-collaborators`). Assign repository permissions to teams rather than individual users for easier management.
+*   **Repository Naming Conventions:** Adopt a consistent naming convention for repositories to make them easily identifiable (e.g., `projectname-frontend`, `projectname-backend`, `projectname-docs`).
+*   **Centralized vs. Distributed Repositories:**
+    *   For smaller projects, a single repository might suffice.
+    *   For larger projects with distinct components (e.g., microservices, separate libraries), consider using multiple repositories. This can improve modularity and allow for more granular access control.
+
+### 2. Sub-Project Structure (within a large repository or across multiple repositories)
+
+*   **Clear Directory Structure:** If using a monorepo, maintain a clear and well-documented directory structure to separate different components or sub-projects.
+*   **CODEOWNERS File:** Utilize the `CODEOWNERS` file to define individuals or teams responsible for code in specific files or directories. This helps automate the assignment of reviewers for pull requests.
+*   **Branching Strategy:** Implement a consistent branching strategy (e.g., Gitflow, GitHub Flow) to manage development, releases, and hotfixes.
+*   **Issue Tracking:** Use GitHub Issues effectively with labels, milestones, and project boards to manage tasks and track progress for each sub-project or component.
+*   **Separate Repositories for Independent Components:** If sub-projects are largely independent and can be developed, tested, and deployed separately, consider making them separate repositories within the organization. This provides the strongest isolation and access control.
+
+### 3. Access Control Best Practices
+
+*   **Principle of Least Privilege:** Grant users and teams only the minimum permissions necessary to perform their tasks.
+*   **Regularly Review Permissions:** Periodically review team memberships and repository access to ensure they are still appropriate.
+*   **Use Branch Protection Rules:** Protect important branches (e.g., `main`, `develop`, release branches) by requiring pull request reviews, status checks, and restricting direct pushes.
+
+## Example Use Cases from the Community
+
+*   **Role-Based Access:** A project with several repositories might need differentiated access levels. Developers working on front-end code might not need (or should not have) access to the backend repositories, and vice versa.
+*   **Code Review & Quality Assurance:** Senior developers or lead engineers might be responsible for code reviews. Structuring teams properly can ensure that pull requests are directed to the appropriate individuals for review. Additionally, certain team members may require the ability to assign reviewers to any PRs (this is a form of helping triage).
+*   **Documentation & Communication:** Teams dedicated to documentation might require access to all repositories but may not need write permissions, just the ability to read and suggest changes.
+*   **Continuous Integration & Deployment:** Those in charge of CI/CD pipelines might need unique permissions to manage hooks, triggers, and deployment keys across various repositories.
+*   **External Collaborators:** In some cases, external consultants or collaborators might need temporary access to certain repositories without giving them access to the entire project.
+*   **Project Management & Oversight:** Project managers or product owners might need an overview access to track progress, without necessarily diving deep into code changes. Their primary interest might be in issues, milestones, and project boards.
+*   **Triage:** Certain team members may be in charge of helping to triage tickets or pull requests, including assigning reviewers or implementors.
+
+## Conclusion
+
+A well-thought-out GitHub organization and sub-project structure is crucial for efficient and secure software development. By considering the needs of different roles and workflows, and by leveraging GitHub's features like Teams and CODEOWNERS, you can create a more manageable and collaborative environment.
+
+Remember to adapt these guidelines to the specific needs and scale of your project.


### PR DESCRIPTION
This pull request introduces a new guidance document on structuring GitHub organizations and sub-projects, as requested in issue #45. 

The document covers key considerations such as:
- Role-Based Access Control (RBAC)
- Code Review and Quality Assurance workflows
- Documentation access
- CI/CD pipeline permissions
- Managing external collaborators
- Project management oversight
- Triage responsibilities

It provides recommended approaches for organization-level structure, sub-project structure (including monorepos vs. multiple repositories), and access control best practices.

Closes #45