### PR TITLE
docs: update SLIM CLI documentation for v2.0.0

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -130,6 +130,25 @@ flowchart TD
     linkStyle 4 stroke-width:3px,stroke:orange;
 ```
 
+### ⚠️ Important Changes in v2.0.0
+
+**Legacy AI support has been deprecated** in favor of the MCP (Model Context Protocol) plugin approach:
+
+- **❌ Deprecated**: Direct `--use-ai <model>` with LiteLLM integration (will show warnings)
+- **✅ New Approach**: Use `--use-ai mcp` to generate coordination prompts for MCP-enabled coding agents
+- **🔧 Migration**: Install the MCP plugin to use AI features with Claude Code, Cursor, Windsurf, Aider, or other compatible coding agents
+
+```bash
+# Old approach (deprecated, will show warnings):
+slim apply --best-practice-ids readme --repo-urls <repo> --use-ai ollama/llama3.1
+
+# New approach (recommended):
+slim apply --best-practice-ids readme --repo-urls <repo> --use-ai mcp
+# Then copy the generated prompts to your coding agent
+```
+
+For seamless AI integration, use the **MCP plugin** with Claude Code, Cursor, Windsurf, Aider, or other compatible coding agents.
+
 ### Demo
 
 Watch SLIM CLI in action:
@@ -152,17 +171,16 @@ This demo showcases the core functionality of SLIM CLI:
 - **Modern CLI Interface**: List, patch, and infuse SLIM best practices into your Git repository workflow using a seamless terminal interface
 - **Fetches the latest SLIM best practices** dynamically from SLIM's registry the moment they change
 - **Patches and pushes**, SLIM best practices to your repository and pushes up to your Git remote (i.e. GitHub) - all automatically
-- **AI Enabled**: 100+ AI models to automatically infuse best practices using AI customization for your repository
+- **AI Enabled**: Integration with coding agents through MCP plugin for AI-powered best practice customization
 - **Extensible Architecture**: Easy-to-extend best practice system with centralized mapping and YAML configuration
 
 ### Getting Started
 
 #### Requirements
 
-* Python 3.7+
+* Python 3.10+ (recommended for MCP server integration)
 * Git
-* **Optional**: LiteLLM for enhanced AI model support (`pip install litellm`)
-* **Optional**: `.env` file to properly configure the environment for AI model APIs
+* **Optional**: For AI features, install the MCP plugin to work with coding agents (Claude Code, Cursor, Windsurf, Aider)
 
 #### Installation
 
@@ -184,45 +202,39 @@ slim list
 # Apply best practices to repositories (using aliases)
 slim apply --best-practice-ids readme --best-practice-ids governance-small --repo-urls https://github.com/your-username/your-repo
 
-# Apply a best practice using AI customization
-slim apply --best-practice-ids readme --repo-urls https://github.com/your-username/your-repo --use-ai azure/gpt-4o
+# Generate AI coordination prompts for coding agents
+slim apply --best-practice-ids readme --repo-urls https://github.com/your-username/your-repo --use-ai mcp
 
 # Apply best practices and then push those changes to a new repository branch on GitHub.com - all automatically
 slim apply-deploy --best-practice-ids readme --best-practice-ids governance-small --repo-urls https://github.com/your-username/your-repo --remote origin --commit-message "Apply SLIM best practices"
 
-# Explore available AI models
+# Explore available AI models (for reference)
 slim models list
 slim models setup anthropic
 ```
 
 ### Documentation Generation
 
-The SLIM CLI includes a website generator that can automatically create [Docusaurus](https://docusaurus.io/) documentation from your repository content:
+The SLIM CLI includes a website generator that can automatically create [Docusaurus](https://docusaurus.io/) documentation from your repository content.
 
 #### Demo
 
-Watch SLIM CLI documentation generation in action:
-
-<p style={{textAlign: 'center', marginBottom: '5px'}}>
-  <a href="#" onClick={(e) => {e.preventDefault(); document.getElementById('slim-cli-docs-video').currentTime = 0; document.getElementById('slim-cli-docs-video').play();}} style={{fontSize: '20px', color: '#666'}}>🔄 Restart Demo</a>
-</p>
-<video id="slim-cli-docs-video" src="/slim/img/tools/slim-cli-demo-docs.webm" width="100%" controls>
-  Your browser does not support the video tag.
-</video>
+🚧 **Coming Soon** - Updated demo video featuring the new MCP plugin workflow will be available in a future release.
 
 #### Example Usage
 
 ```bash
-# Generate documentation with AI enhancement using local Ollama Llama 3.1
-slim apply --best-practice-ids docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai ollama/llama3.1
-
-# Generate documentation with AI enhancement using Anthropic Claude
-slim apply --best-practice-ids docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai anthropic/claude-3-5-sonnet-20241022
+# Generate documentation with AI coordination prompts for coding agents
+slim apply --best-practice-ids docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai mcp
 ```
 
-**AI Model Recommendations:**
-- **Recommended**: Use cloud-based models like `openai/gpt-4o-mini`, `azure/gpt-4o`, or `anthropic/claude-3-5-sonnet-20241022` for best documentation quality
-- **Local models**: While supported (e.g., `ollama/llama3.1`), local models typically produce lower quality documentation
+**Recommended Approach:**
+- Use `--use-ai mcp` to generate coordination prompts
+- Copy the prompts to your coding agent (Claude Code, Cursor, Windsurf, Aider)
+- Let your coding agent handle the AI-powered customization
+
+**Example MCP Prompt:**
+*"Apply the SLIM docs-website best practice to generate a Docusaurus documentation site for this repository. Customize the content based on the project structure and README."*
 
 ### Unit Test Generation
 
@@ -230,7 +242,7 @@ slim apply --best-practice-ids docs-website --repo-dir /path/to/your/repo --outp
 
 ### AI Models Discovery
 
-SLIM CLI supports 100+ AI models through LiteLLM integration with automatic model discovery:
+SLIM CLI supports model discovery and recommendations for use with coding agents:
 
 ```bash
 # List all available models (100+ models from various providers)
@@ -247,6 +259,7 @@ slim models recommend --task code_generation --tier fast
 
 # Get setup instructions for specific providers
 slim models setup anthropic
+slim models setup openai
 slim models setup ollama
 
 # Validate model configuration and test connectivity
@@ -261,6 +274,31 @@ slim models validate ollama/llama3.1
 - **Local/Private**: Ollama, VLLM, LM Studio, GPT4All
 - **Enterprise**: Azure OpenAI, AWS Bedrock, Google Vertex AI
 
+### MCP Plugin Integration
+
+SLIM CLI includes a **Model Context Protocol (MCP) plugin** that enables seamless integration with coding agents like Claude Code, Cursor, Windsurf, Aider, and other MCP-compatible tools.
+
+#### Key Features
+
+- **Natural Language Interface**: Apply SLIM best practices using conversational AI commands
+- **Repository Context Awareness**: Automatically analyzes your repository structure and customizes templates
+- **Real-time Best Practices**: Fetches the latest SLIM best practices from the live registry
+- **AI-Powered Customization**: Leverages your coding agent's capabilities for intelligent template customization
+
+#### Quick Setup for Claude Code
+
+1. **Install SLIM CLI** (if not already installed):
+   ```bash
+   pip install slim-cli
+   ```
+
+2. **Add the MCP server to Claude Code** - see the [GitHub repository](https://github.com/nasa-ammos/slim-cli) for detailed setup instructions
+
+3. **Use in your coding agent**:
+   - Simply ask: *"Apply the SLIM readme best practice with AI customization"*
+   - Or: *"List all available SLIM best practices"*
+   - Or: *"Apply governance template to this repository"*
+
 ### Learn More
 
-For more detailed information about SLIM CLI, visit the [GitHub repository](https://github.com/nasa-ammos/slim-cli).
+For more detailed information about SLIM CLI, including MCP setup and migration guides, visit the [GitHub repository](https://github.com/nasa-ammos/slim-cli).


### PR DESCRIPTION
Updates SLIM website documentation to reflect changes in SLIM CLI v2.0.0.

See full release details: https://github.com/NASA-AMMOS/slim-cli/releases/tag/v2.0.0

Key updates:
- Added breaking changes section for AI integration deprecation
- Updated examples to use new MCP plugin approach with coding agents
- Added MCP plugin integration documentation

Fixes compatibility with SLIM CLI v2.0.0 release.