### PR TITLE
Fix registry and zip URLs to support custom baseUrl

### DIFF
--- a/src/components/SkillBrowser.js
+++ b/src/components/SkillBrowser.js
@@ -1327,17 +1327,18 @@ const SkillBrowser = ({ searchTerm, setSearchTerm, isSearchActive }) => {
         return registryPath;
       }
       // Local path - convert to Docusaurus static file URL
+      const docBaseUrl = siteConfig.baseUrl || "/";
       if (registryPath.startsWith("./static/")) {
         // Remove './static/' prefix since Docusaurus serves static files directly
         const staticPath = registryPath.substring("./static/".length);
-        return `${baseUrl}/slim/${staticPath}`;
+        return `${baseUrl}${docBaseUrl}${staticPath}`;
       }
       if (registryPath.startsWith("./")) {
-        return `${baseUrl}/slim/${registryPath.substring(2)}`;
+        return `${baseUrl}${docBaseUrl}${registryPath.substring(2)}`;
       }
-      return `${baseUrl}/slim/${registryPath}`;
+      return `${baseUrl}${docBaseUrl}${registryPath}`;
     },
-    [baseUrl],
+    [baseUrl, siteConfig.baseUrl],
   );
 
   // Helper function to get registry base URL for zip resolution
@@ -1350,10 +1351,11 @@ const SkillBrowser = ({ searchTerm, setSearchTerm, isSearchActive }) => {
         const url = new URL(registryPath);
         return `${url.protocol}//${url.host}`;
       }
-      // Local path
-      return baseUrl;
+      // Local path - include the docusaurus baseUrl
+      const docBaseUrl = siteConfig.baseUrl || "/";
+      return `${baseUrl}${docBaseUrl}`.replace(/\/$/, ""); // Remove trailing slash
     },
-    [baseUrl],
+    [baseUrl, siteConfig.baseUrl],
   );
 
   // Load available registries from build-time config


### PR DESCRIPTION
## Summary

This PR fixes hardcoded `/slim/` paths in `SkillBrowser.js` to use `siteConfig.baseUrl` dynamically, enabling SLIM forks with different base paths to work correctly.

## Problem

The current implementation hardcodes `/slim/` in two functions:
1. `getRegistryUrl()` - constructs registry.json URLs
2. `getRegistryBaseUrl()` - constructs zip file download URLs

This breaks for SLIM forks that use different `baseUrl` values in their `docusaurus.config.js`.

## Changes

### `getRegistryUrl()`
**Before:**
```javascript
return `${baseUrl}/slim/${staticPath}`;
```

**After:**
```javascript
const docBaseUrl = siteConfig.baseUrl || "/";
return `${baseUrl}${docBaseUrl}${staticPath}`;
```

### `getRegistryBaseUrl()`
**Before:**
```javascript
// Local path
return baseUrl;
```

**After:**
```javascript
// Local path - include the docusaurus baseUrl
const docBaseUrl = siteConfig.baseUrl || "/";
return `${baseUrl}${docBaseUrl}`.replace(/\/$/, ""); // Remove trailing slash
```

## Impact

### For SLIM (baseUrl: `/slim/`)
- ✅ No behavior change - continues to work as before
- Registry URL: `https://nasa-ammos.github.io/slim/data/registry.json`
- Zip URLs: `https://nasa-ammos.github.io/slim/assets/zip/skill-name.zip`

### For SLIM Forks (e.g., baseUrl: `/custom-path/`)
- ✅ Registry and zip URLs now use correct base path
- Registry URL: `https://example.com/custom-path/data/registry.json`
- Zip URLs: `https://example.com/custom-path/assets/zip/skill-name.zip`

## Testing

Tested with:
- SLIM with `baseUrl: "/slim/"` - works correctly
- Fork with `baseUrl: "/MAAP-Project/maap-ai/"` - now works correctly

## Benefits

- Makes SLIM more reusable as a framework for other projects
- Fixes broken registry loading in forked projects
- Fixes broken install command URLs in forked projects
- No breaking changes for existing SLIM deployment